### PR TITLE
Bugfix#1

### DIFF
--- a/src/pymars/__init__.py
+++ b/src/pymars/__init__.py
@@ -20,6 +20,16 @@ def main() -> None:
 
     with open(args.input_file, "r") as f:
         simulation_parameters = yaml.safe_load(f)
+    
+    # Set FENNOL_MODULES_PATH BEFORE any fennol imports
+    # This allows FeNNol to automatically load custom modules from the model directory
+    model_file = simulation_parameters.get("model_file") or simulation_parameters.get("model")
+    if model_file:
+        from pathlib import Path
+        model_path = Path(model_file).resolve()
+        if model_path.exists():
+            model_dir = str(model_path.parent)
+            os.environ['FENNOL_MODULES_PATH'] = model_dir
 
     from fennol.utils.input_parser import convert_dict_units
     from .utils import us

--- a/src/pymars/__init__.py
+++ b/src/pymars/__init__.py
@@ -62,6 +62,10 @@ def main() -> None:
     species = system["species"]
     masses = system["masses"]
     batch_size = system["batch_size"]
+    
+    # Convert atomic numbers to element symbols for trajectory output
+    from ase.data import chemical_symbols
+    element_symbols = [chemical_symbols[z] for z in species]
 
     simulation_time = simulation_parameters["simulation_time"]  # ps
     dt = system["dt"]  # ps
@@ -120,7 +124,7 @@ def main() -> None:
                 for i in range(batch_size):
                     write_xyz_frame(
                         ftraj[i],
-                        species,
+                        element_symbols,
                         coords[i],
                         comment=f"Step {istep+1} E_pot={potential_energy:.6f}",
                     )

--- a/src/pymars/md.py
+++ b/src/pymars/md.py
@@ -119,39 +119,7 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
     assert model_path.is_file(), f"Model file {model_file} does not exist."
     print(f"# Using FENNIX model from file: {model_file}")
     
-    # Add model directory to sys.path so fennol can find auxiliary files (e.g., custom architecture definitions)
-    import sys
-    import importlib.util
-    model_dir = str(model_path.parent.resolve())
-    if model_dir not in sys.path:
-        sys.path.insert(0, model_dir)
-    
-    # Import any Python modules in the model directory to register custom architectures
-    import glob
-    from fennol.models.fennix import MODULES
-    for py_file in glob.glob(str(Path(model_dir) / "*.py")):
-        if not py_file.endswith("__init__.py"):
-            module_name = Path(py_file).stem
-            try:
-                spec = importlib.util.spec_from_file_location(module_name, py_file)
-                if spec and spec.loader:
-                    module = importlib.util.module_from_spec(spec)
-                    spec.loader.exec_module(module)
-                    # Register any classes with FID attribute as custom modules
-                    for attr_name in dir(module):
-                        attr = getattr(module, attr_name)
-                        if hasattr(attr, '__mro__') and hasattr(attr, '__doc__'):
-                            if attr.__doc__ and 'FID :' in attr.__doc__:
-                                # Extract FID from docstring
-                                for line in attr.__doc__.split('\n'):
-                                    if 'FID :' in line:
-                                        fid = line.split('FID :')[1].strip()
-                                        MODULES[fid.upper()] = attr
-                                        print(f"# Registered custom module: {fid}")
-                                        break
-            except Exception as e:
-                print(f"# Warning: Could not import {module_name}: {e}")
-    
+    # Load FeNNol model (FENNOL_MODULES_PATH already set in __init__.py)
     from fennol import FENNIX
     model = FENNIX.load(model_file)
     model.preproc_state = model.preproc_state.copy({"check_input": False})

--- a/src/pymars/md.py
+++ b/src/pymars/md.py
@@ -121,9 +121,36 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
     
     # Add model directory to sys.path so fennol can find auxiliary files (e.g., custom architecture definitions)
     import sys
+    import importlib.util
     model_dir = str(model_path.parent.resolve())
     if model_dir not in sys.path:
         sys.path.insert(0, model_dir)
+    
+    # Import any Python modules in the model directory to register custom architectures
+    import glob
+    from fennol.models.fennix import MODULES
+    for py_file in glob.glob(str(Path(model_dir) / "*.py")):
+        if not py_file.endswith("__init__.py"):
+            module_name = Path(py_file).stem
+            try:
+                spec = importlib.util.spec_from_file_location(module_name, py_file)
+                if spec and spec.loader:
+                    module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(module)
+                    # Register any classes with FID attribute as custom modules
+                    for attr_name in dir(module):
+                        attr = getattr(module, attr_name)
+                        if hasattr(attr, '__mro__') and hasattr(attr, '__doc__'):
+                            if attr.__doc__ and 'FID :' in attr.__doc__:
+                                # Extract FID from docstring
+                                for line in attr.__doc__.split('\n'):
+                                    if 'FID :' in line:
+                                        fid = line.split('FID :')[1].strip()
+                                        MODULES[fid.upper()] = attr
+                                        print(f"# Registered custom module: {fid}")
+                                        break
+            except Exception as e:
+                print(f"# Warning: Could not import {module_name}: {e}")
     
     from fennol import FENNIX
     model = FENNIX.load(model_file)

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -27,12 +27,19 @@ def test_model_file_key_handling():
         }
         
         # This will fail when trying to actually load the model (it's not a real fennol model)
-        # but it should get past the key validation
+        # but it should get past the key validation (not raise ValueError about missing key)
         try:
             system = initialize_collision_simulation(config_with_model_file, verbose=False)
-        except Exception as e:
-            # We expect this to fail at model loading, not at key validation
-            assert "model_file" not in str(e).lower() and "model" not in str(e).lower()
+            # If we got here, the model loaded successfully (unexpected)
+            assert False, "Expected model loading to fail with dummy file"
+        except ValueError as e:
+            # If ValueError is raised, it should NOT be about missing model key
+            if "Configuration must contain either" in str(e):
+                raise AssertionError(f"Key validation failed unexpectedly: {e}")
+            # Other ValueErrors are expected from model loading
+        except Exception:
+            # Any other exception is expected (model loading will fail)
+            pass
         
         # Test with 'model' key (legacy support)
         config_with_model = {
@@ -46,9 +53,14 @@ def test_model_file_key_handling():
         
         try:
             system = initialize_collision_simulation(config_with_model, verbose=False)
-        except Exception as e:
-            # We expect this to fail at model loading, not at key validation
-            assert "model_file" not in str(e).lower() and "model" not in str(e).lower()
+            assert False, "Expected model loading to fail with dummy file"
+        except ValueError as e:
+            # If ValueError is raised, it should NOT be about missing model key
+            if "Configuration must contain either" in str(e):
+                raise AssertionError(f"Key validation failed unexpectedly: {e}")
+        except Exception:
+            # Any other exception is expected (model loading will fail)
+            pass
         
         # Test with neither key - should raise ValueError
         config_without_model = {

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,0 +1,66 @@
+import pytest
+from pathlib import Path
+import tempfile
+
+
+def test_model_file_key_handling():
+    """Test that both 'model' and 'model_file' keys are supported"""
+    from pymars.md import initialize_collision_simulation
+    
+    # Create a temporary model file (just for path validation test)
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.pkl', delete=False) as f:
+        temp_model_path = f.name
+        f.write("dummy")  # Write something so it's a valid file
+    
+    try:
+        test_data_dir = Path(__file__).parent
+        
+        # Test with 'model_file' key (as shown in README)
+        config_with_model_file = {
+            'initial_geometry': str(test_data_dir / "aspirin.xyz"),
+            'model_file': temp_model_path,
+            'simulation_time': 1.0,
+            'dt': 0.001,
+            'batch_size': 1,
+            'temperature': 300.0,
+        }
+        
+        # This will fail when trying to actually load the model (it's not a real fennol model)
+        # but it should get past the key validation
+        try:
+            system = initialize_collision_simulation(config_with_model_file, verbose=False)
+        except Exception as e:
+            # We expect this to fail at model loading, not at key validation
+            assert "model_file" not in str(e).lower() or "model" not in str(e).lower()
+        
+        # Test with 'model' key (legacy support)
+        config_with_model = {
+            'initial_geometry': str(test_data_dir / "aspirin.xyz"),
+            'model': temp_model_path,
+            'simulation_time': 1.0,
+            'dt': 0.001,
+            'batch_size': 1,
+            'temperature': 300.0,
+        }
+        
+        try:
+            system = initialize_collision_simulation(config_with_model, verbose=False)
+        except Exception as e:
+            # We expect this to fail at model loading, not at key validation
+            assert "model_file" not in str(e).lower() or "model" not in str(e).lower()
+        
+        # Test with neither key - should raise ValueError
+        config_without_model = {
+            'initial_geometry': str(test_data_dir / "aspirin.xyz"),
+            'simulation_time': 1.0,
+            'dt': 0.001,
+            'batch_size': 1,
+            'temperature': 300.0,
+        }
+        
+        with pytest.raises(ValueError, match="Configuration must contain either 'model_file' or 'model' key"):
+            system = initialize_collision_simulation(config_without_model, verbose=False)
+    
+    finally:
+        # Clean up temp file
+        Path(temp_model_path).unlink(missing_ok=True)

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -11,7 +11,8 @@ def test_model_file_key_handling():
     # Create a temporary model file (just for path validation test)
     with tempfile.NamedTemporaryFile(mode='w', suffix='.pkl', delete=False) as f:
         temp_model_path = f.name
-        f.write("dummy")  # Write something so it's a valid file
+        # Write dummy content (not valid pickle) to test path handling
+        f.write("dummy")
     
     try:
         test_data_dir = Path(__file__).parent
@@ -127,9 +128,13 @@ def test_model_directory_added_to_syspath():
             # Verify that model directory was added to sys.path
             assert model_dir_str in sys.path, f"Model directory {model_dir_str} should be in sys.path"
             
-            # Verify we can import the auxiliary file
-            import custom_module
-            assert custom_module.TEST_VARIABLE == 'model_dir_in_path'
+            # Verify we can import the auxiliary file using dynamic import
+            import importlib
+            try:
+                custom_module = importlib.import_module('custom_module')
+                assert custom_module.TEST_VARIABLE == 'model_dir_in_path'
+            except ImportError as e:
+                raise AssertionError(f"Failed to import custom_module from model directory: {e}")
             
         finally:
             # Clean up sys.modules and sys.path

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,6 +1,7 @@
 import pytest
 from pathlib import Path
 import tempfile
+import sys
 
 
 def test_model_file_key_handling():
@@ -31,7 +32,7 @@ def test_model_file_key_handling():
             system = initialize_collision_simulation(config_with_model_file, verbose=False)
         except Exception as e:
             # We expect this to fail at model loading, not at key validation
-            assert "model_file" not in str(e).lower() or "model" not in str(e).lower()
+            assert "model_file" not in str(e).lower() and "model" not in str(e).lower()
         
         # Test with 'model' key (legacy support)
         config_with_model = {
@@ -47,7 +48,7 @@ def test_model_file_key_handling():
             system = initialize_collision_simulation(config_with_model, verbose=False)
         except Exception as e:
             # We expect this to fail at model loading, not at key validation
-            assert "model_file" not in str(e).lower() or "model" not in str(e).lower()
+            assert "model_file" not in str(e).lower() and "model" not in str(e).lower()
         
         # Test with neither key - should raise ValueError
         config_without_model = {
@@ -64,3 +65,64 @@ def test_model_file_key_handling():
     finally:
         # Clean up temp file
         Path(temp_model_path).unlink(missing_ok=True)
+
+
+def test_model_directory_added_to_syspath():
+    """Test that model directory is added to sys.path for auxiliary file imports"""
+    from pymars.md import initialize_collision_simulation
+    
+    # Create a temporary directory structure with model and auxiliary files
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        
+        # Create a model subdirectory
+        model_dir = tmpdir / "model_dir"
+        model_dir.mkdir()
+        
+        # Create a dummy model file
+        model_file = model_dir / "test_model.pkl"
+        model_file.write_text("dummy")
+        
+        # Create a dummy auxiliary Python file (like recraster.py)
+        aux_file = model_dir / "custom_module.py"
+        aux_file.write_text("TEST_VARIABLE = 'model_dir_in_path'")
+        
+        test_data_dir = Path(__file__).parent
+        config = {
+            'initial_geometry': str(test_data_dir / "aspirin.xyz"),
+            'model_file': str(model_file),
+            'simulation_time': 1.0,
+            'dt': 0.001,
+            'batch_size': 1,
+            'temperature': 300.0,
+        }
+        
+        # Store original sys.path
+        original_syspath = sys.path.copy()
+        model_dir_str = str(model_dir.resolve())
+        
+        # Ensure model_dir is not in sys.path before the test
+        if model_dir_str in sys.path:
+            sys.path.remove(model_dir_str)
+        
+        try:
+            # This will fail at model loading, but should add the directory to sys.path first
+            try:
+                system = initialize_collision_simulation(config, verbose=False)
+            except Exception:
+                pass  # Expected to fail on actual model loading
+            
+            # Verify that model directory was added to sys.path
+            assert model_dir_str in sys.path, f"Model directory {model_dir_str} should be in sys.path"
+            
+            # Verify we can import the auxiliary file
+            import custom_module
+            assert custom_module.TEST_VARIABLE == 'model_dir_in_path'
+            
+        finally:
+            # Clean up sys.modules and sys.path
+            if 'custom_module' in sys.modules:
+                del sys.modules['custom_module']
+            if model_dir_str in sys.path:
+                sys.path.remove(model_dir_str)
+


### PR DESCRIPTION
close #1
A):Issue: Trajectory files were writing atomic numbers (18, 6, 8, 7, 1) instead of element symbols (Ar, C, O, N, H)
Fix: Convert atomic numbers to element symbols using ASE's chemical_symbols before writing trajectory
Changes: Modified __init__.py
Branch: bugfix#2 pushed to origin
Commit: e63b81c
B)Fixes file reading issue
Support both model and model_file config keys
Add model directory to sys.path (for custom architectures)
Better error handling
C)Automates module discovery and registration from model directory