### PR TITLE
Add restart trajectory functionality and track variance option

### DIFF
--- a/examples/input.yaml
+++ b/examples/input.yaml
@@ -51,6 +51,7 @@ output_details:
   #   - "energies_0.out"
   #   - "energies_1.out"
   
+  track_variance: false  # If true, add a variance column to energies.out (if model supports it)
   summary_file: "summary.out"  # Output summary statistics file (requires save_summary in general_parameters)
 
 # Energy file format:

--- a/examples/input.yaml
+++ b/examples/input.yaml
@@ -5,6 +5,7 @@ calculation_parameters:
   device: cpu  # Options: 'cpu', 'cuda:0', 'gpu:0', etc. Default: cpu
   model: "/path/to/fennix/model.fnx"  # Path to FENNIX model file
   double_precision: false  # Use double precision (float64) instead of single (float32). Default: false
+  restart_traj: false  # If true, continue from <initialxyzfilename>.dyn.restart if it exists; always saves last state
 
 general_parameters:
   temperature: 300.0  # Temperature in Kelvin

--- a/examples/input.yaml
+++ b/examples/input.yaml
@@ -51,11 +51,15 @@ output_details:
   #   - "energies_0.out"
   #   - "energies_1.out"
   
-  track_variance: false  # If true, add a variance column to energies.out (if model supports it)
+  track_variance: false  # If true, add a Var(eV^2) column to energies.out using the model's etot_ensemble_var.
+                        # Requires a FeNNol model that exposes 'etot_ensemble_var' in its auxiliary output.
+                        # Automatically disabled (with a warning) when batch_size > 1.
   summary_file: "summary.out"  # Output summary statistics file (requires save_summary in general_parameters)
 
-# Energy file format:
+# Energy file format (track_variance: false):
 #     Step   Time[fs]       Etot       Epot       Ekin    Temp[K]
+# Energy file format (track_variance: true, model supports etot_ensemble_var):
+#     Step   Time[fs]       Etot       Epot       Ekin    Temp[K]   Var(eV^2)
 # Where:
 #   Step: Integration step number
 #   Time[fs]: Time in femtoseconds
@@ -63,3 +67,4 @@ output_details:
 #   Epot: Potential energy (kcal/mol)
 #   Ekin: Kinetic energy (kcal/mol)
 #   Temp[K]: Temperature (Kelvin)
+#   Var(eV^2): Per-frame ensemble energy variance from model (eV^2); 'None' if model does not provide it.

--- a/src/pymars/__init__.py
+++ b/src/pymars/__init__.py
@@ -271,7 +271,7 @@ def main() -> None:
     
     header = f"#{'Step':>10} {'Time[fs]':>12} {'Etot':>12} {'Epot':>12} {'Ekin':>12} {'ns/day':>12}"
     if track_variance:
-        header += f" {'Var':>12}"
+        header += f" {'Var(eV^2)':>12}"
     print(header)
     for istep in range(start_step, n_steps):
         coordinates, velocities, accelerations, energies, energy_data = integrate(
@@ -292,16 +292,15 @@ def main() -> None:
             drift = abs(current_total_energy - initial_total_energy)
             max_energy_drift = max(max_energy_drift, drift)
 
-        # Extract variance if requested and available
+        # Extract variance if requested and available — only from model-provided etot_ensemble_var
         variance_val = None
         if track_variance:
             # Try to get variance from energy_data or energies
-            if energy_data is not None and "variances" in energy_data:
-                variance_val = np.mean(energy_data["variances"])
-            elif hasattr(energies, "var"):
-                variance_val = float(np.var(energies))
-            else:
-                variance_val = 0.0
+            if energy_data is not None and "variances" in energy_data and energy_data["variances"] is not None:
+                try:
+                    variance_val = float(np.mean(energy_data["variances"]))
+                except Exception:
+                    variance_val = None
 
         if (istep + 1) % save_steps == 0:
             time_elapsed = time.time() - time0
@@ -324,7 +323,10 @@ def main() -> None:
 
             line = f" {istep+1:10} {time_str:>12} {total_energy:12.3f} {potential_energy:12.3f} {ekin:12.3f} {ns_per_day:12.1f}"
             if track_variance:
-                line += f" {variance_val:12.5f}"
+                if variance_val is None:
+                    line += f" {'None':>12s}"
+                else:
+                    line += f" {variance_val:12.5f}"
             print(line)
 
             if write_traj:

--- a/src/pymars/__init__.py
+++ b/src/pymars/__init__.py
@@ -270,11 +270,9 @@ def main() -> None:
     energy_history = []  # Store energy data for summary statistics
     
     header = f"#{'Step':>10} {'Time[fs]':>12} {'Etot':>12} {'Epot':>12} {'Ekin':>12} {'ns/day':>12}"
-    if track_variance:
-        header += f" {'Var(eV^2)':>12}"
     print(header)
     for istep in range(start_step, n_steps):
-        coordinates, velocities, accelerations, energies, energy_data = integrate(
+        coordinates, velocities, accelerations, energies, energy_data, frame_variance = integrate(
             coordinates, velocities, accelerations,
             step=istep,
             energy_output_file=energy_files if energy_file else None,
@@ -291,16 +289,6 @@ def main() -> None:
             current_total_energy = np.mean(energy_data['total_energies'])
             drift = abs(current_total_energy - initial_total_energy)
             max_energy_drift = max(max_energy_drift, drift)
-
-        # Extract variance if requested and available — only from model-provided etot_ensemble_var
-        variance_val = None
-        if track_variance:
-            # Try to get variance from energy_data or energies
-            if energy_data is not None and "variances" in energy_data and energy_data["variances"] is not None:
-                try:
-                    variance_val = float(np.mean(energy_data["variances"]))
-                except Exception:
-                    variance_val = None
 
         if (istep + 1) % save_steps == 0:
             time_elapsed = time.time() - time0
@@ -322,11 +310,6 @@ def main() -> None:
                 time_str = f"{time_fs:.{time_decimals}f}"
 
             line = f" {istep+1:10} {time_str:>12} {total_energy:12.3f} {potential_energy:12.3f} {ekin:12.3f} {ns_per_day:12.1f}"
-            if track_variance:
-                if variance_val is None:
-                    line += f" {'None':>12s}"
-                else:
-                    line += f" {variance_val:12.5f}"
             print(line)
 
             if write_traj:

--- a/src/pymars/__init__.py
+++ b/src/pymars/__init__.py
@@ -35,10 +35,17 @@ def main() -> None:
     initial_xyz = input_params.get("initial_geometry", None)
     if initial_xyz is not None:
         base_xyz = os.path.basename(initial_xyz)
-        restart_file = os.path.splitext(base_xyz)[0] + ".dyn.restart"
+        restart_file_name = os.path.splitext(base_xyz)[0] + ".dyn.restart"
     else:
-        restart_file = "traj.dyn.restart"
+        restart_file_name = "traj.dyn.restart"
     restart_traj = bool(calc_params.get("restart_traj", False))
+
+    # Determine restart file path: place the restart file next to the input YAML
+    input_yaml_dir = os.path.dirname(os.path.abspath(args.input_file))
+    restart_file = os.path.join(input_yaml_dir, restart_file_name)
+    # Also show where we'll look/save restart files
+    # (useful when working directories or folder names change)
+    print(f"# Restart file will be: {restart_file}")
 
     # Note: postpone importing fennol/.utils (which may import jax) until after
     # we've set CUDA_VISIBLE_DEVICES and configured JAX so device detection
@@ -149,20 +156,28 @@ def main() -> None:
     batch_size = system["batch_size"]
     start_step = 0
 
-    # If restart_traj is true and restart file exists, load state
-    if restart_traj and os.path.exists(restart_file):
-        print(f"# Restarting trajectory from {restart_file}")
-        arr = np.load(restart_file)
-        coordinates = arr["coordinates"]
-        velocities = arr["velocities"]
-        accelerations = arr["accelerations"]
-        if "step" in arr:
-            start_step = int(arr["step"])
+    # If restart_traj is true, try to locate a restart file. numpy.savez
+    # appends a .npz extension if it is not present, so check both
+    # '<prefix>.dyn.restart' and '<prefix>.dyn.restart.npz'.
+    if restart_traj:
+        candidates = [restart_file, restart_file + ".npz"]
+        found = None
+        for p in candidates:
+            if os.path.exists(p):
+                found = p
+                break
+        if found is not None:
+            print(f"# Restarting trajectory from {found}")
+            arr = np.load(found)
+            coordinates = arr["coordinates"]
+            velocities = arr["velocities"]
+            accelerations = arr["accelerations"]
+            if "step" in arr:
+                start_step = int(arr["step"])
+            else:
+                start_step = 0
         else:
-            start_step = 0
-    else:
-        if restart_traj:
-            print(f"# restart_traj is True but {restart_file} not found, starting from initial configuration.")
+            print(f"# restart_traj is True but no restart file found among: {candidates}; starting from initial configuration.")
     
     # Convert atomic numbers to element symbols for trajectory output
     from ase.data import chemical_symbols
@@ -392,10 +407,25 @@ def main() -> None:
         for f in ftraj: 
             f.close()
     # --- Always save last state for restart ---
+    # Ensure directory exists (should, as it's input yaml dir)
+    try:
+        os.makedirs(os.path.dirname(restart_file), exist_ok=True)
+    except Exception:
+        pass
+    # Convert JAX arrays to numpy before saving to ensure compatibility
+    try:
+        save_coords = np.asarray(coordinates)
+        save_vels = np.asarray(velocities)
+        save_accs = np.asarray(accelerations)
+    except Exception:
+        save_coords = coordinates
+        save_vels = velocities
+        save_accs = accelerations
+
     np.savez(restart_file,
-        coordinates=coordinates,
-        velocities=velocities,
-        accelerations=accelerations,
+        coordinates=save_coords,
+        velocities=save_vels,
+        accelerations=save_accs,
         step=n_steps
     )
     print(f"# Saved last state to {restart_file}")

--- a/src/pymars/__init__.py
+++ b/src/pymars/__init__.py
@@ -407,13 +407,15 @@ def main() -> None:
         save_vels = velocities
         save_accs = accelerations
 
-    np.savez(restart_file,
+    # Ensure we know the exact filename np.savez will create
+    restart_save_file = restart_file if restart_file.endswith(".npz") else restart_file + ".npz"
+    np.savez(restart_save_file,
         coordinates=save_coords,
         velocities=save_vels,
         accelerations=save_accs,
         step=n_steps
     )
-    print(f"# Saved last state to {restart_file}")
+    print(f"# Saved last state to {restart_save_file}")
     from fennol.utils.io import human_time_duration
     total_time = time.time() - time_start
     nsperday = (simulation_time / total_time)*60*60*24*us.NS

--- a/src/pymars/md.py
+++ b/src/pymars/md.py
@@ -191,8 +191,13 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
             coordinates_model = full_coordinates[:, 1:, :]
             projectile_coordinates = full_coordinates[:, 0, :]
             energies_model, forces_model, aux = model._energy_and_forces(model.variables, conformation)
-            # Extract per-frame ensemble variance if model provides it (units: eV^2, not converted)
-            etot_ensemble_var = aux.get("etot_ensemble_var", None) if isinstance(aux, dict) else None
+            # Extract per-frame ensemble variance if model provides it (units: eV^2, not converted).
+            # Always return a JAX array here so that JIT tracing is not broken when the key is absent.
+            if isinstance(aux, dict) and "etot_ensemble_var" in aux:
+                etot_ensemble_var = aux["etot_ensemble_var"]
+            else:
+                # Use NaN as a sentinel for "missing" ensemble variance; downstream code can detect this.
+                etot_ensemble_var = jnp.full_like(energies_model, jnp.nan)
             energies_repulsion, forces_repulsion, projectile_forces = (
                 repulsion_energies_and_forces(coordinates_model, projectile_coordinates)
             )

--- a/src/pymars/md.py
+++ b/src/pymars/md.py
@@ -36,6 +36,11 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
     projectile_params = simulation_parameters.get("projectile_parameters", {})
     calculation_params = simulation_parameters.get("calculation_parameters", {})
     dynamic_params = simulation_parameters.get("dynamic_parameters", {})
+    # Output options
+    output_params = simulation_parameters.get("output_details", {})
+    track_variance = bool(output_params.get("track_variance", False))
+    # Variance tracking requires batch_size==1 (model etot_ensemble_var is per-frame, not across trajectories)
+    # The guard below will be enforced after batch_size is known.
     
     # Support both nested and flat (legacy) formats
     # If nested sections don't exist, fall back to top-level keys
@@ -83,6 +88,15 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
     # batch size for parallel simulations
     batch_size = general_params.get("batch_size", 1)
     assert batch_size >= 1, "batch_size must be at least 1"
+
+    # Batch-size guard for variance tracking
+    if track_variance and batch_size > 1:
+        print(
+            "# WARNING: track_variance is enabled but batch_size > 1. "
+            "etot_ensemble_var is a per-frame per-trajectory quantity and cannot be "
+            "meaningfully tracked across batch trajectories. Disabling track_variance."
+        )
+        track_variance = False
 
     # random rotation
     do_random_rotation = input_params.get("random_rotation", True)
@@ -176,7 +190,9 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
             # full_coordinates expected shape (batch_size, N+1, 3) as jnp array
             coordinates_model = full_coordinates[:, 1:, :]
             projectile_coordinates = full_coordinates[:, 0, :]
-            energies_model, forces_model, _ = model._energy_and_forces(model.variables, conformation)
+            energies_model, forces_model, aux = model._energy_and_forces(model.variables, conformation)
+            # Extract per-frame ensemble variance if model provides it (units: eV^2, not converted)
+            etot_ensemble_var = aux.get("etot_ensemble_var", None) if isinstance(aux, dict) else None
             energies_repulsion, forces_repulsion, projectile_forces = (
                 repulsion_energies_and_forces(coordinates_model, projectile_coordinates)
             )
@@ -186,7 +202,7 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
             full_forces = jnp.concatenate(
                 [projectile_forces[:, None, :], total_forces], axis=1
             )  # (batch_size,N+1,3)
-            return total_energies, full_forces
+            return total_energies, full_forces, etot_ensemble_var
 
         full_species = np.concatenate(
             [np.array([projectile_species], dtype=np.int32), species]
@@ -202,11 +218,13 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
         def total_energies_and_forces(full_coordinates, conformation):
             # full_coordinates shape (batch_size, N, 3)
             coordinates_model = full_coordinates[:, :, :]
-            energies_model, forces_model, _ = model._energy_and_forces(model.variables, conformation)
+            energies_model, forces_model, aux = model._energy_and_forces(model.variables, conformation)
+            # Extract per-frame ensemble variance if model provides it (units: eV^2, not converted)
+            etot_ensemble_var = aux.get("etot_ensemble_var", None) if isinstance(aux, dict) else None
             total_energies = energies_model * energy_conv
             total_forces = forces_model.reshape(coordinates_model.shape[0], -1, 3) * energy_conv
             full_forces = total_forces  # (batch_size,N,3)
-            return total_energies, full_forces
+            return total_energies, full_forces, etot_ensemble_var
 
         full_species = species.copy()  # (N,)
         full_coordinates = coordinates.copy()  # (batch_size,N,3)
@@ -220,7 +238,7 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
     conformation = model.preprocess(use_gpu=True, **initial_conformation)
     # Ensure full_coordinates passed as jnp arrays to energy/force function
     full_coordinates_jnp = jnp.array(full_coordinates, dtype=jnp.float32)
-    energies, forces = total_energies_and_forces(full_coordinates_jnp, conformation)
+    energies, forces, _ = total_energies_and_forces(full_coordinates_jnp, conformation)
     accelerations = forces / masses  # (batch_size, N(+1), 3) depending on collision
 
     # prepare integrator
@@ -237,10 +255,9 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
         return coordinates, velocities
     
     @jax.jit
-    def integrate_part2(coordinates, velocities,conformation):
-        energies, forces = total_energies_and_forces(coordinates,conformation)
+    def integrate_part2(coordinates, velocities, conformation):
+        energies, forces, _var = total_energies_and_forces(coordinates, conformation)
         accelerations = forces / masses  # (batch_size,N+1,3)
-
         velocities = velocities + accelerations * dt2  # (batch_size,N,3)
         return velocities, accelerations, energies  # energies is (batch_size,)
 
@@ -249,7 +266,7 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
         coordinates, velocities = integrate_part1(
             initial_coordinates, initial_velocities, accelerations
         )
-        
+
         # Update conformation for model preprocessing
         if collision:
             # For collision dynamics, exclude projectile (index 0)
@@ -257,24 +274,35 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
         else:
             # For non-collision dynamics, use all coordinates
             coords_for_model = coordinates
-            
-        conformation = model.preprocess(use_gpu=True,**update_conformation(
+
+        conformation = model.preprocess(use_gpu=True, **update_conformation(
             initial_conformation, coords_for_model))
 
         velocities, accelerations, energies = integrate_part2(
-            coordinates, velocities,conformation
+            coordinates, velocities, conformation
         )
+
+        # Extract per-frame variance from model (outside jit, only when needed)
+        frame_variance = None
+        if track_variance and energy_output_file is not None and step % energy_steps == 0:
+            try:
+                _, _, aux_var = total_energies_and_forces(coordinates, conformation)
+                if aux_var is not None:
+                    frame_variance = np.atleast_1d(np.array(aux_var))
+            except Exception:
+                frame_variance = None
 
         # Write energy output if requested
         energy_data = None
         if energy_output_file is not None and step % energy_steps == 0:
             energy_data = write_energy_output(
-                energy_output_file, step, velocities, masses, energies, dt
+                energy_output_file, step, velocities, masses, energies, dt,
+                frame_variance=frame_variance
             )
 
         return coordinates, velocities, accelerations, energies, energy_data
 
-    def write_energy_output(output_file, step, velocities, masses, potential_energies, dt):
+    def write_energy_output(output_file, step, velocities, masses, potential_energies, dt, frame_variance=None):
         """Write energy data to output file in FeNNol format."""
         # Compute kinetic energy: 0.5 * m * v^2
         # masses is already shaped (1, N, 1) for broadcasting
@@ -295,26 +323,22 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
         
         # Time in femtoseconds - determine precision based on dt
         time_fs = step * dt * 1000.0  # dt is in ps, convert to fs
-        # Determine decimal places: if dt=1.0 fs, show 0 decimals; if dt=0.1, show 1, etc.
         dt_fs = dt * 1000.0  # Convert dt from ps to fs
         if dt_fs >= 1.0:
             time_decimals = 0
         else:
-            # Count decimal places needed
             time_decimals = len(str(dt_fs).split('.')[-1].rstrip('0'))
         time_format = f"{{:.{time_decimals}f}}"
         
         # Convert JAX arrays to numpy for file writing
-        total_energies_np = np.array(total_energies)
-        potential_energies_np = np.array(potential_energies)
-        kinetic_energies_np = np.array(kinetic_energies)
-        temperatures_np = np.array(temperatures)
-        
-        # Ensure arrays are at least 1D for concatenation in summary statistics
-        total_energies_np = np.atleast_1d(total_energies_np)
-        potential_energies_np = np.atleast_1d(potential_energies_np)
-        kinetic_energies_np = np.atleast_1d(kinetic_energies_np)
-        temperatures_np = np.atleast_1d(temperatures_np)
+        total_energies_np = np.atleast_1d(np.array(total_energies))
+        potential_energies_np = np.atleast_1d(np.array(potential_energies))
+        kinetic_energies_np = np.atleast_1d(np.array(kinetic_energies))
+        temperatures_np = np.atleast_1d(np.array(temperatures))
+
+        # Normalise frame_variance: must be 1D numpy array of length batch_size, or None
+        if frame_variance is not None:
+            frame_variance = np.atleast_1d(np.array(frame_variance))
         
         # Write to file for each trajectory in batch
         for b in range(batch_size):
@@ -322,12 +346,16 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
                 file_path = output_file[b]
             else:
                 file_path = output_file if batch_size == 1 else f"{output_file}_{b}"
-            
+
             # Create file with header if step == 0
             if step == 0:
                 with open(file_path, 'w') as f:
-                    f.write(f"{'Step':>8s} {'Time[fs]':>12s} {'Etot':>12s} {'Epot':>12s} {'Ekin':>12s} {'Temp[K]':>10s}\n")
-            
+                    header = f"{'Step':>8s} {'Time[fs]':>12s} {'Etot':>12s} {'Epot':>12s} {'Ekin':>12s} {'Temp[K]':>10s}"
+                    if track_variance:
+                        header += f" {'Var(eV^2)':>12s}"
+                    header += "\n"
+                    f.write(header)
+
             # Append energy data
             with open(file_path, 'a') as f:
                 # Extract scalar values properly
@@ -335,19 +363,31 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
                 pot_e = float(potential_energies_np.flat[b] if potential_energies_np.size > 1 else potential_energies_np)
                 kin_e = float(kinetic_energies_np.flat[b] if kinetic_energies_np.size > 1 else kinetic_energies_np)
                 temp = float(temperatures_np.flat[b] if temperatures_np.size > 1 else temperatures_np)
-                
+
                 # Format time with appropriate precision
                 time_str = time_format.format(time_fs)
-                f.write(f"{step:8d} {time_str:>12s} {total_e:12.6f} "
-                       f"{pot_e:12.6f} {kin_e:12.6f} "
-                       f"{temp:10.2f}\n")
-        
+                line = f"{step:8d} {time_str:>12s} {total_e:12.6f} {pot_e:12.6f} {kin_e:12.6f} {temp:10.2f}"
+                if track_variance:
+                    # Use model-provided etot_ensemble_var (eV^2); write None if not available
+                    if frame_variance is not None:
+                        var_val = float(frame_variance.flat[b] if frame_variance.size > 1 else frame_variance[0])
+                        line += f" {var_val:12.5f}\n"
+                    else:
+                        line += f" {'None':>12s}\n"
+                else:
+                    line += "\n"
+                f.write(line)
+
         # Return energy data for summary statistics
+        # variances are from model (eV^2); None if not provided
+        var_arr = frame_variance  # already numpy or None
+
         return {
             'total_energies': total_energies_np,
             'potential_energies': potential_energies_np,
             'kinetic_energies': kinetic_energies_np,
-            'temperatures': temperatures_np
+            'temperatures': temperatures_np,
+            'variances': var_arr,
         }
 
     return {

--- a/src/pymars/md.py
+++ b/src/pymars/md.py
@@ -282,9 +282,12 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
             coordinates, velocities, conformation
         )
 
-        # Extract per-frame variance from model (outside jit, only when needed)
+        # Extract per-frame variance from model (outside jit) when requested.
+        # We obtain it every step when track_variance is True so the caller
+        # (main loop) can print it even if energy file is only written at a
+        # different interval.
         frame_variance = None
-        if track_variance and energy_output_file is not None and step % energy_steps == 0:
+        if track_variance:
             try:
                 _, _, aux_var = total_energies_and_forces(coordinates, conformation)
                 if aux_var is not None:
@@ -300,7 +303,7 @@ def initialize_collision_simulation(simulation_parameters, verbose=True):
                 frame_variance=frame_variance
             )
 
-        return coordinates, velocities, accelerations, energies, energy_data
+        return coordinates, velocities, accelerations, energies, energy_data, frame_variance
 
     def write_energy_output(output_file, step, velocities, masses, potential_energies, dt, frame_variance=None):
         """Write energy data to output file in FeNNol format."""

--- a/tests/test_variance_tracking.py
+++ b/tests/test_variance_tracking.py
@@ -102,7 +102,7 @@ class TestVarianceTracking:
 
         mock_model = _make_mock_model(etot_ensemble_var=expected_var, n_atoms=21)
 
-        with patch("pymars.md.FENNIX") as MockFENNIX:
+        with patch("fennol.FENNIX") as MockFENNIX:
             MockFENNIX.load.return_value = mock_model
             system = initialize_collision_simulation(sim_params, verbose=False)
 

--- a/tests/test_variance_tracking.py
+++ b/tests/test_variance_tracking.py
@@ -1,0 +1,232 @@
+"""
+Tests for track_variance functionality.
+
+These tests mock model._energy_and_forces to return a known etot_ensemble_var value
+and verify that:
+  1. The Var(eV^2) column appears in the energies output file when track_variance=True.
+  2. The written value matches the model-provided etot_ensemble_var.
+  3. 'None' is written when the model does not return etot_ensemble_var.
+  4. track_variance is disabled (with a warning) when batch_size > 1.
+"""
+import os
+import tempfile
+import numpy as np
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_sim_params(track_variance: bool, batch_size: int, tmpdir: str, xyz_path: str) -> dict:
+    return {
+        "input_parameters": {
+            "initial_geometry": str(xyz_path),
+            "total_charge": 0,
+            "random_rotation": False,
+        },
+        "general_parameters": {
+            "temperature": 0.0,
+            "batch_size": batch_size,
+            "save_steps": 1,
+            "save_energy": 1,
+        },
+        "calculation_parameters": {
+            "model": str(Path(__file__).parent / "mock_model.fnx"),
+            "device": "cpu",
+        },
+        "dynamic_parameters": {
+            "dt_dyn": 1.0,
+        },
+        "output_details": {
+            "trajectory_file": os.path.join(tmpdir, "traj.xyz"),
+            "energies_file": os.path.join(tmpdir, "energies.out"),
+            "track_variance": track_variance,
+        },
+        "thermostat_parameters": {
+            "NVE_thermostat": True,
+        },
+    }
+
+
+def _make_mock_model(etot_ensemble_var=None, n_atoms=21, batch_size=1):
+    """Return a mock FENNIX model that returns a fixed aux dict."""
+    model = MagicMock()
+    model.energy_unit = "eV"
+
+    # Preprocess and preproc_state
+    model.preproc_state = MagicMock()
+    model.preproc_state.copy.return_value = model.preproc_state
+
+    def fake_preprocess(**kwargs):
+        conformation = dict(kwargs)
+        return conformation
+    model.preprocess.side_effect = fake_preprocess
+
+    # _energy_and_forces returns (energies, forces, aux)
+    energies = np.zeros(batch_size, dtype=np.float32)
+    forces = np.zeros((batch_size, n_atoms, 3), dtype=np.float32)
+
+    if etot_ensemble_var is not None:
+        aux = {"etot_ensemble_var": np.full(batch_size, etot_ensemble_var, dtype=np.float32)}
+    else:
+        aux = {}
+
+    model._energy_and_forces.return_value = (energies, forces, aux)
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestVarianceTracking:
+    """Tests for etot_ensemble_var extraction and output."""
+
+    def test_variance_written_to_file_when_model_provides_it(self, tmp_path, test_data_dir):
+        """When model returns etot_ensemble_var, the Var(eV^2) column is written correctly."""
+        xyz = test_data_dir / "aspirin.xyz"
+        if not xyz.exists():
+            pytest.skip("aspirin.xyz not found in test data dir")
+
+        sim_params = _build_sim_params(
+            track_variance=True, batch_size=1,
+            tmpdir=str(tmp_path), xyz_path=xyz
+        )
+
+        expected_var = 0.12345
+
+        from pymars.md import initialize_collision_simulation
+
+        mock_model = _make_mock_model(etot_ensemble_var=expected_var, n_atoms=21)
+
+        with patch("pymars.md.FENNIX") as MockFENNIX:
+            MockFENNIX.load.return_value = mock_model
+            system = initialize_collision_simulation(sim_params, verbose=False)
+
+        integrate = system["integrate"]
+        coords = system["coordinates"]
+        vels = system["velocities"]
+        accs = system["accelerations"]
+        energy_file = sim_params["output_details"]["energies_file"]
+
+        # Run one step
+        coords, vels, accs, energies, energy_data = integrate(
+            coords, vels, accs,
+            step=0,
+            energy_output_file=[energy_file],
+            energy_steps=1,
+        )
+
+        # Check energies file was created
+        assert os.path.exists(energy_file), "energies.out not created"
+
+        with open(energy_file) as f:
+            lines = f.readlines()
+
+        # Header should contain Var(eV^2)
+        header = lines[0]
+        assert "Var(eV^2)" in header, f"Var(eV^2) not in header: {header!r}"
+
+        # Data line should have numeric variance
+        data_line = lines[1].strip()
+        fields = data_line.split()
+        var_field = fields[-1]
+        assert var_field != "None", "Expected a numeric variance, got None"
+        assert abs(float(var_field) - expected_var) < 1e-4, (
+            f"Variance mismatch: expected {expected_var}, got {var_field}"
+        )
+
+        # energy_data should expose variances
+        assert energy_data is not None
+        assert energy_data.get("variances") is not None
+        assert abs(float(energy_data["variances"][0]) - expected_var) < 1e-4
+
+    def test_variance_none_when_model_does_not_provide_it(self, tmp_path, test_data_dir):
+        """When model does not return etot_ensemble_var, 'None' is written in Var column."""
+        xyz = test_data_dir / "aspirin.xyz"
+        if not xyz.exists():
+            pytest.skip("aspirin.xyz not found in test data dir")
+
+        sim_params = _build_sim_params(
+            track_variance=True, batch_size=1,
+            tmpdir=str(tmp_path), xyz_path=xyz
+        )
+
+        from pymars.md import initialize_collision_simulation
+        mock_model = _make_mock_model(etot_ensemble_var=None, n_atoms=21)
+
+        with patch("pymars.md.FENNIX") as MockFENNIX:
+            MockFENNIX.load.return_value = mock_model
+            system = initialize_collision_simulation(sim_params, verbose=False)
+
+        integrate = system["integrate"]
+        coords = system["coordinates"]
+        vels = system["velocities"]
+        accs = system["accelerations"]
+        energy_file = sim_params["output_details"]["energies_file"]
+
+        coords, vels, accs, energies, energy_data = integrate(
+            coords, vels, accs,
+            step=0,
+            energy_output_file=[energy_file],
+            energy_steps=1,
+        )
+
+        with open(energy_file) as f:
+            lines = f.readlines()
+
+        assert "Var(eV^2)" in lines[0], "Var(eV^2) column missing from header"
+        data_line = lines[1].strip()
+        fields = data_line.split()
+        assert fields[-1] == "None", f"Expected 'None' in variance column, got {fields[-1]!r}"
+
+    def test_variance_disabled_for_batch_gt1(self, tmp_path, test_data_dir, capsys):
+        """When batch_size > 1 and track_variance=True, warning is printed and column not written."""
+        xyz = test_data_dir / "aspirin.xyz"
+        if not xyz.exists():
+            pytest.skip("aspirin.xyz not found in test data dir")
+
+        batch_size = 2
+        sim_params = _build_sim_params(
+            track_variance=True, batch_size=batch_size,
+            tmpdir=str(tmp_path), xyz_path=xyz
+        )
+
+        from pymars.md import initialize_collision_simulation
+        mock_model = _make_mock_model(etot_ensemble_var=0.5, n_atoms=21, batch_size=batch_size)
+
+        with patch("pymars.md.FENNIX") as MockFENNIX:
+            MockFENNIX.load.return_value = mock_model
+            system = initialize_collision_simulation(sim_params, verbose=True)
+
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out and "track_variance" in captured.out, (
+            "Expected a track_variance warning for batch_size > 1"
+        )
+
+        # energies file should NOT have a Var column since track_variance was disabled
+        integrate = system["integrate"]
+        coords = system["coordinates"]
+        vels = system["velocities"]
+        accs = system["accelerations"]
+
+        energy_files = [
+            str(tmp_path / f"energies_{b}.out") for b in range(batch_size)
+        ]
+
+        coords, vels, accs, energies, energy_data = integrate(
+            coords, vels, accs,
+            step=0,
+            energy_output_file=energy_files,
+            energy_steps=1,
+        )
+
+        with open(energy_files[0]) as f:
+            header = f.readline()
+
+        assert "Var(eV^2)" not in header, (
+            "Var(eV^2) column should not appear when track_variance was disabled for batch>1"
+        )


### PR DESCRIPTION
This pull request adds two important features to the simulation workflow: support for restarting trajectories from a saved state and the ability to track and output the variance of energies during simulation. Additionally, it ensures that the simulation always saves its last state for future restarts. These enhancements improve the usability and reproducibility of simulations, especially for long or interrupted runs.

### **Trajectory restart support:**

* Added a `restart_traj` parameter to the input YAML (`examples/input.yaml`) and implemented logic in `src/pymars/__init__.py` to detect, load, and resume from a restart file (either `<initialxyzfilename>.dyn.restart` or with a `.npz` extension) if it exists. The restart file is saved in the same directory as the input YAML, and the code prints the restart file path being used. [[1]](diffhunk://#diff-81d013da0b1bac784ae466ffd516126207f1166ec519f52297c1447f6ed624c7R8) [[2]](diffhunk://#diff-a14c9260d98b000b999514964068a1020aa93ba7022b02b88b660b5c13f0b6ddR33-R49) [[3]](diffhunk://#diff-a14c9260d98b000b999514964068a1020aa93ba7022b02b88b660b5c13f0b6ddR150-R180)

* At the end of every simulation run, the last state (coordinates, velocities, accelerations, and step) is always saved to the appropriate restart file, ensuring future runs can resume from where they left off.

### **Energy variance tracking:**

* Added a `track_variance` parameter to the input YAML (`examples/input.yaml`) and code to `src/pymars/__init__.py` to optionally compute and print a variance column in the energies output, if supported by the model. The header and output line formatting are updated accordingly. [[1]](diffhunk://#diff-81d013da0b1bac784ae466ffd516126207f1166ec519f52297c1447f6ed624c7R54) [[2]](diffhunk://#diff-a14c9260d98b000b999514964068a1020aa93ba7022b02b88b660b5c13f0b6ddR232-R234) [[3]](diffhunk://#diff-a14c9260d98b000b999514964068a1020aa93ba7022b02b88b660b5c13f0b6ddL227-R276) [[4]](diffhunk://#diff-a14c9260d98b000b999514964068a1020aa93ba7022b02b88b660b5c13f0b6ddR295-R305) [[5]](diffhunk://#diff-a14c9260d98b000b999514964068a1020aa93ba7022b02b88b660b5c13f0b6ddL266-R329)
### 
**File changes:**
* **Code** 
__init__.py
Added deterministic restart behavior:
Restart file name derived from input_parameters.initial_geometry (basename + ".dyn.restart").
Restart file path is now placed next to the input YAML (so restart works even if CWD / folder name changed).
Loader now checks both "<prefix>.dyn.restart" and "<prefix>.dyn.restart.npz" (numpy.savez appends .npz).
Saver explicitly writes to "<prefix>.dyn.restart.npz".
Converts JAX arrays to NumPy before saving to ensure portability.
Added calculation_parameters.restart_traj control (boolean): when true, loader attempts to resume.
Added output_details.track_variance handling (console + energies output column) earlier on this branch.
Improved logging for diagnostics (prints restart file path, saved path, device selection messages).
* **Example / docs**
input.yaml updated: added restart_traj and track_variance options and comments.